### PR TITLE
feat: support raw images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,21 @@
 FROM ubuntu:22.04 AS dependencies
 
-RUN apt-get update && apt-get install python3 python3-pip build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev wget curl git -y
+RUN apt-get update && apt-get install \
+    python3 \
+    python3-pip \
+    build-essential \
+    zlib1g-dev \
+    libncurses5-dev \
+    libgdbm-dev \
+    libnss3-dev \
+    libssl-dev \
+    libreadline-dev \
+    libffi-dev \
+    libmagic1 \
+    wget \
+    curl \
+    git -y
+
 RUN pip install --upgrade setuptools
 
 FROM dependencies AS pip_dependencies
@@ -9,8 +24,9 @@ WORKDIR /opt/app
 ADD requirements.txt setup.cfg setup.py /opt/app/
 RUN --mount=type=cache,target=/root/.cache/pip pip install -e .
 
-FROM dependencies AS models
+FROM ubuntu:22.04 AS models
 
+RUN apt-get update && apt-get install wget -y
 RUN mkdir -p /data/pretrained/
 RUN wget -O /data/pretrained/ram_plus_swin_large_14m.pth https://huggingface.co/xinyu1205/recognize-anything-plus-model/resolve/main/ram_plus_swin_large_14m.pth
 RUN wget -O /data/pretrained/ram_swin_large_14m.pth https://huggingface.co/spaces/xinyu1205/Recognize_Anything-Tag2Text/resolve/main/ram_swin_large_14m.pth

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ uvicorn
 fastapi
 python-multipart
 pydantic-settings
+rawpy
+python-magic


### PR DESCRIPTION
- use python-magic to determine whether an uploaded file is a tiff
- pass tiff images through rawpy before handing off to pillow
- re-jig dockerfile to better cache model stage

tested with .nef files from a Nikon, and .arw files from a Sony A7